### PR TITLE
Add missing argument

### DIFF
--- a/proc/src/lib.rs
+++ b/proc/src/lib.rs
@@ -136,7 +136,7 @@ fn diagnostic_derive(s: Structure) -> Result<TokenStream> {
                             let message = attr_to_format(&attr, &members)?;
 
                             quote! {
-                                ::codespan_derive::IntoLabel::into_label( #binding )
+                                ::codespan_derive::IntoLabel::into_label( #binding, ::codespan_derive::LabelStyle::#style )
                                     .with_message( #message )
                             }
                         }


### PR DESCRIPTION
Adds the label style argument to the `into_label` call when a message is given on span attributes. The style parameter was added in the recent change to the `IntoLabel` trait. 