### PR TITLE
Add support for `FileId` types with lifetimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Derive macro for ergonomically creating a Diagnostic from an error macro
 ## Usage
 
 1. Add `#[derive(IntoDiagnostic)]` onto your error macro type.
-2. Add a `#[file_id(Type)]` to signal what the `FileId` generic type of the `Diagnostic` will be.
+2. Add a `#[file_id(Type)]` to signal what the `FileId` generic type of the `Diagnostic` will be. If your `FileId` type requires a lifetime, you can use `'a`.
 3. Tag every variant with a `#[message = ""]` signalling what the error message should read.
 4. Span-like values that implement `IntoLabel` can be tagged with `#[primary]` or `#[secondary]` to be marked in the generated error, with an optional message like `#[primary = ""]`.
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,62 @@
+use std::ops::Range;
+
+use codespan_derive::{IntoDiagnostic, IntoLabel, Label, LabelStyle};
+use codespan_reporting::{
+    files::SimpleFiles,
+    term::{
+        self,
+        termcolor::{ColorChoice, StandardStream},
+    },
+};
+
+/// A source span to store a `file:byte range`
+struct Span {
+    file_id: usize,
+    range: Range<usize>,
+}
+
+impl IntoLabel for Span {
+    type FileId = usize;
+
+    fn into_label(&self, style: LabelStyle) -> Label<Self::FileId> {
+        Label::new(style, self.file_id, self.range.clone())
+    }
+}
+
+#[derive(IntoDiagnostic)]
+#[file_id(usize)]
+enum Error {
+    #[message = "This is an error: {message}"]
+    Example {
+        message: &'static str,
+
+        #[primary = "This is a primary span"]
+        primary_span: Span,
+
+        #[secondary = "This is a secondary span"]
+        secondary_span: Span,
+    },
+}
+
+fn main() {
+    let mut files: SimpleFiles<&'static str, &'static str> = SimpleFiles::new();
+    let file_id = files.add("example.txt", "Test Case");
+
+    let err = Error::Example {
+        message: "This is a stored message",
+        primary_span: Span {
+            file_id,
+            range: 5..9,
+        },
+        secondary_span: Span {
+            file_id,
+            range: 0..4,
+        },
+    };
+
+    // Basic codespan-diagnostic printing to terminal
+    let writer = StandardStream::stderr(ColorChoice::Always);
+    let config = codespan_reporting::term::Config::default();
+    term::emit(&mut writer.lock(), &config, &files, &err.into_diagnostic())
+        .expect("Failed to show diagnostic");
+}

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -16,9 +16,9 @@ struct Span {
 }
 
 impl IntoLabel for Span {
-    type FileId = usize;
+    type FileId<'a> = usize;
 
-    fn into_label(&self, style: LabelStyle) -> Label<Self::FileId> {
+    fn into_label(&self, style: LabelStyle) -> Label<Self::FileId<'_>> {
         Label::new(style, self.file_id, self.range.clone())
     }
 }

--- a/examples/ref_fileid.rs
+++ b/examples/ref_fileid.rs
@@ -1,0 +1,99 @@
+use std::ops::Range;
+
+use codespan_derive::{IntoDiagnostic, IntoLabel, Label, LabelStyle};
+use codespan_reporting::{
+    files::{self, Files, SimpleFile},
+    term::{
+        self,
+        termcolor::{ColorChoice, StandardStream},
+    },
+};
+
+/// Example implementation of `Files` that treats a &str path as the file ID
+///
+/// For the sake of brevity, this implementation returns the same file regardless
+/// of ID
+struct ExampleFiles {
+    file: SimpleFile<String, String>,
+}
+
+impl<'a> Files<'a> for ExampleFiles {
+    /// The file ID for this Files impl is a reference (eg. for an FS path)
+    type FileId = &'a str;
+    type Name = &'a str;
+    type Source = &'a str;
+
+    fn name(&'a self, id: Self::FileId) -> Result<Self::Name, files::Error> {
+        Ok(id)
+    }
+
+    fn source(&'a self, _: Self::FileId) -> Result<Self::Source, files::Error> {
+        Ok(self.file.source())
+    }
+
+    fn line_index(&'a self, _: Self::FileId, byte_index: usize) -> Result<usize, files::Error> {
+        self.file.line_index((), byte_index)
+    }
+
+    fn line_range(
+        &'a self,
+        _: Self::FileId,
+        line_index: usize,
+    ) -> Result<Range<usize>, files::Error> {
+        self.file.line_range((), line_index)
+    }
+}
+
+/// This span owns its file ID rather than keep a reference
+struct Span {
+    file_id: String,
+    range: Range<usize>,
+}
+
+impl IntoLabel for Span {
+    type FileId<'a> = &'a str;
+
+    fn into_label(&self, style: LabelStyle) -> Label<Self::FileId<'_>> {
+        Label::new(style, self.file_id.as_str(), self.range.clone())
+    }
+}
+
+#[derive(IntoDiagnostic)]
+// codespan-derive provides a lifetime argument 'a for reference-type file IDs
+#[file_id(&'a str)]
+enum Error {
+    #[message = "This is an error: {message}"]
+    Example {
+        message: &'static str,
+
+        #[primary = "This is a primary span"]
+        primary_span: Span,
+
+        #[secondary = "This is a secondary span"]
+        secondary_span: Span,
+    },
+}
+
+fn main() {
+    let files = ExampleFiles {
+        file: SimpleFile::new("empty.txt".into(), "Test Case".into()),
+    };
+
+    let err = Error::Example {
+        message: "This is a stored message",
+        primary_span: Span {
+            file_id: "example1.txt".to_string(),
+            range: 5..9,
+        },
+        secondary_span: Span {
+            file_id: "example2.txt".to_string(),
+            range: 0..4,
+        },
+    };
+
+    // Basic codespan-diagnostic printing to terminal
+    let writer = StandardStream::stderr(ColorChoice::Always);
+    let config = codespan_reporting::term::Config::default();
+    term::emit(&mut writer.lock(), &config, &files, &err.into_diagnostic())
+        .expect("Failed to show diagnostic");
+}

--- a/proc/src/lib.rs
+++ b/proc/src/lib.rs
@@ -200,7 +200,7 @@ fn diagnostic_derive(s: Structure) -> Result<TokenStream> {
         if let Some((why, _)) = why {
             branches.push(quote! {
                 #pat => {
-                    ::codespan_derive::Diagnostic::< #file_id >::error()
+                    ::codespan_derive::Diagnostic::error()
                         .with_message( #why )
                         .with_labels(vec![ #(#labels),* ])
                         .with_notes(vec![ #(#notes),* ])
@@ -224,10 +224,10 @@ fn diagnostic_derive(s: Structure) -> Result<TokenStream> {
 
     Ok(s.gen_impl(quote! {
         gen impl ::codespan_derive::IntoDiagnostic for @Self {
-            type FileId = #file_id ;
+            type FileId<'a> = #file_id ;
 
             #[allow(dead_code)]
-            fn into_diagnostic(&self) -> ::codespan_derive::Diagnostic::< #file_id > {
+            fn into_diagnostic(&self) -> ::codespan_derive::Diagnostic::<Self::FileId<'_>> {
                 match self {
                     #(#branches),*
                     _ => { panic!("Uninhabited type cannot be turned into a Diagnostic") }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,17 @@ pub use codespan_derive_proc::IntoDiagnostic;
 pub use codespan_reporting::diagnostic::{Diagnostic, Label, LabelStyle};
 
 pub trait IntoDiagnostic {
-    type FileId;
+    type FileId<'a>: 'a
+    where
+        Self: 'a;
 
-    fn into_diagnostic(&self) -> Diagnostic<Self::FileId>;
+    fn into_diagnostic(&self) -> Diagnostic<Self::FileId<'_>>;
 }
 
 pub trait IntoLabel {
-    type FileId;
+    type FileId<'a>: 'a
+    where
+        Self: 'a;
 
-    fn into_label(&self, style: LabelStyle) -> Label<Self::FileId>;
+    fn into_label(&self, style: LabelStyle) -> Label<Self::FileId<'_>>;
 }


### PR DESCRIPTION
This PR allows the use of `FileId` types that require a lifetime, with a particular example being references. Examples have also been added to showcase both approaches.

Both `IntoDiagnostic::FileId` and `IntoLabel::FileId` are now generic over a lifetime parameter `'a`. When using `#[file_id]`, you can use `'a` whenever a lifetime is necessary.

This is a breaking API change since impls of `IntoLabel` now need to account for the new lifetime parameter.

Fixes #5.