### PR TITLE
Add support for Optional/Multiple labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Derive macro for ergonomically creating a Diagnostic from an error macro
 ## Usage
 
 1. Add `#[derive(IntoDiagnostic)]` onto your error macro type.
-2. Add a `#[file_id(Type)]` to signal what the `FileId` generic type of the `Diagnostic` will be.
+2. Add a `#[file_id(Type)]` to signal what the `FileId` generic type of the `Diagnostic` will be. If your `FileId` type requires a lifetime, you can use `'a`.
 3. Tag every variant with a `#[message = ""]` signalling what the error message should read.
 4. Span-like values that implement `IntoLabel` can be tagged with `#[primary]` or `#[secondary]` to be marked in the generated error, with an optional message like `#[primary = ""]`.
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ Derive macro for ergonomically creating a Diagnostic from an error macro
 
 1. Add `#[derive(IntoDiagnostic)]` onto your error macro type.
 2. Add a `#[file_id(Type)]` to signal what the `FileId` generic type of the `Diagnostic` will be. If your `FileId` type requires a lifetime, you can use `'a`.
-3. Tag every variant with a `#[message = ""]` signalling what the error message should read.
-4. Span-like values that implement `IntoLabel` can be tagged with `#[primary]` or `#[secondary]` to be marked in the generated error, with an optional message like `#[primary = ""]`.
+3. Add a `#[severity(Ident)]` to denote the severity of the diagnostic. `Ident` should be one of the variants of `codespan_reporting::Severity`.
+4. Tag every variant with a `#[message = ""]` signalling what the error message should read.
+5. Span-like values that implement `IntoLabel` can be tagged with `#[primary]` or `#[secondary]` to be marked in the generated error, with an optional message like `#[primary = ""]`.
 
 ```rust
 #[derive(IntoDiagnostic)]
 #[file_id(SomeFileIdType)]
+#[severity(Error)]
 enum Error {
   #[message = "Compiler found the number `{0}` is too large"]
   NumberTooLarge(usize),

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Derive macro for ergonomically creating a Diagnostic from an error macro
 2. Add a `#[file_id(Type)]` to signal what the `FileId` generic type of the `Diagnostic` will be. If your `FileId` type requires a lifetime, you can use `'a`.
 3. Add a `#[severity(Ident)]` to denote the severity of the diagnostic. `Ident` should be one of the variants of `codespan_reporting::Severity`.
 4. Tag every variant with a `#[message = ""]` signalling what the error message should read.
-5. Span-like values that implement `IntoLabel` can be tagged with `#[primary]` or `#[secondary]` to be marked in the generated error, with an optional message like `#[primary = ""]`.
+5. Span-like values that implement `IntoLabel` can be tagged with `#[primary]` or `#[secondary]` to be marked in the generated error, with an optional message like `#[primary = ""]`. Optional labels can be specified with `Option<T>`, and varying lists of labels can be specified with `Vec<T>`.
 
 ```rust
 #[derive(IntoDiagnostic)]
@@ -23,6 +23,8 @@ enum Error {
     string: String,
     #[primary = "The bad string appears here"]
     span: Span,
+    #[secondary = "The bad string also potentially appears here"]
+    span_2: Option<Span>,
   },
 }
 ```

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use codespan_derive::{IntoDiagnostic, IntoLabel, Label, LabelStyle};
+use codespan_derive::{IntoDiagnostic, IntoLabels, Label, LabelStyle};
 use codespan_reporting::{
     files::SimpleFiles,
     term::{
@@ -15,11 +15,11 @@ struct Span {
     range: Range<usize>,
 }
 
-impl IntoLabel for Span {
+impl IntoLabels for Span {
     type FileId<'a> = usize;
 
-    fn into_label(&self, style: LabelStyle) -> Label<Self::FileId<'_>> {
-        Label::new(style, self.file_id, self.range.clone())
+    fn into_labels(&self, style: LabelStyle) -> Vec<Label<Self::FileId<'_>>> {
+        vec![Label::new(style, self.file_id, self.range.clone())]
     }
 }
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,62 @@
+use std::ops::Range;
+
+use codespan_derive::{IntoDiagnostic, IntoLabel, Label, LabelStyle};
+use codespan_reporting::{
+    files::SimpleFiles,
+    term::{
+        self,
+        termcolor::{ColorChoice, StandardStream},
+    },
+};
+
+/// A source span to store a `file:byte range`
+struct Span {
+    file_id: usize,
+    range: Range<usize>,
+}
+
+impl IntoLabel for Span {
+    type FileId = usize;
+
+    fn into_label(&self, style: LabelStyle) -> Label<Self::FileId> {
+        Label::new(style, self.file_id, self.range.clone())
+    }
+}
+
+#[derive(IntoDiagnostic)]
+#[file_id(usize)]
+enum Error {
+    #[message = "This is an error: {message}"]
+    Example {
+        message: &'static str,
+
+        #[primary = "This is a primary span"]
+        primary_span: Span,
+
+        #[secondary = "This is a secondary span"]
+        secondary_span: Span,
+    },
+}
+
+fn main() {
+    let mut files: SimpleFiles<&'static str, &'static str> = SimpleFiles::new();
+    let file_id = files.add("example.txt", "Test Case");
+
+    let err = Error::Example {
+        message: "This is a stored message",
+        primary_span: Span {
+            file_id,
+            range: 5..9,
+        },
+        secondary_span: Span {
+            file_id,
+            range: 0..4,
+        },
+    };
+
+    // Basic codespan-diagnostic printing to terminal
+    let writer = StandardStream::stderr(ColorChoice::Always);
+    let config = codespan_reporting::term::Config::default();
+    term::emit(&mut writer.lock(), &config, &files, &err.into_diagnostic())
+        .expect("Failed to show diagnostic");
+}

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -16,9 +16,9 @@ struct Span {
 }
 
 impl IntoLabel for Span {
-    type FileId = usize;
+    type FileId<'a> = usize;
 
-    fn into_label(&self, style: LabelStyle) -> Label<Self::FileId> {
+    fn into_label(&self, style: LabelStyle) -> Label<Self::FileId<'_>> {
         Label::new(style, self.file_id, self.range.clone())
     }
 }

--- a/examples/ref_fileid.rs
+++ b/examples/ref_fileid.rs
@@ -1,0 +1,99 @@
+use std::ops::Range;
+
+use codespan_derive::{IntoDiagnostic, IntoLabel, Label, LabelStyle};
+use codespan_reporting::{
+    files::{self, Files, SimpleFile},
+    term::{
+        self,
+        termcolor::{ColorChoice, StandardStream},
+    },
+};
+
+/// Example implementation of `Files` that treats a &str path as the file ID
+///
+/// For the sake of brevity, this implementation returns the same file regardless
+/// of ID
+struct ExampleFiles {
+    file: SimpleFile<String, String>,
+}
+
+impl<'a> Files<'a> for ExampleFiles {
+    /// The file ID for this Files impl is a reference (eg. for an FS path)
+    type FileId = &'a str;
+    type Name = &'a str;
+    type Source = &'a str;
+
+    fn name(&'a self, id: Self::FileId) -> Result<Self::Name, files::Error> {
+        Ok(id)
+    }
+
+    fn source(&'a self, _: Self::FileId) -> Result<Self::Source, files::Error> {
+        Ok(self.file.source())
+    }
+
+    fn line_index(&'a self, _: Self::FileId, byte_index: usize) -> Result<usize, files::Error> {
+        self.file.line_index((), byte_index)
+    }
+
+    fn line_range(
+        &'a self,
+        _: Self::FileId,
+        line_index: usize,
+    ) -> Result<Range<usize>, files::Error> {
+        self.file.line_range((), line_index)
+    }
+}
+
+/// This span owns its file ID rather than keep a reference
+struct Span {
+    file_id: String,
+    range: Range<usize>,
+}
+
+impl IntoLabel for Span {
+    type FileId<'a> = &'a str;
+
+    fn into_label(&self, style: LabelStyle) -> Label<Self::FileId<'_>> {
+        Label::new(style, self.file_id.as_str(), self.range.clone())
+    }
+}
+
+#[derive(IntoDiagnostic)]
+// codespan-derive provides a lifetime argument 'a for reference-type file IDs
+#[file_id(&'a str)]
+enum Error {
+    #[message = "This is an error: {message}"]
+    Example {
+        message: &'static str,
+
+        #[primary = "This is a primary span"]
+        primary_span: Span,
+
+        #[secondary = "This is a secondary span"]
+        secondary_span: Span,
+    },
+}
+
+fn main() {
+    let files = ExampleFiles {
+        file: SimpleFile::new("empty.txt".into(), "Test Case".into()),
+    };
+
+    let err = Error::Example {
+        message: "This is a stored message",
+        primary_span: Span {
+            file_id: "example1.txt".to_string(),
+            range: 5..9,
+        },
+        secondary_span: Span {
+            file_id: "example2.txt".to_string(),
+            range: 0..4,
+        },
+    };
+
+    // Basic codespan-diagnostic printing to terminal
+    let writer = StandardStream::stderr(ColorChoice::Always);
+    let config = codespan_reporting::term::Config::default();
+    term::emit(&mut writer.lock(), &config, &files, &err.into_diagnostic())
+        .expect("Failed to show diagnostic");
+}

--- a/examples/ref_fileid.rs
+++ b/examples/ref_fileid.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use codespan_derive::{IntoDiagnostic, IntoLabel, Label, LabelStyle};
+use codespan_derive::{IntoDiagnostic, IntoLabels, Label, LabelStyle};
 use codespan_reporting::{
     files::{self, Files, SimpleFile},
     term::{
@@ -50,11 +50,11 @@ struct Span {
     range: Range<usize>,
 }
 
-impl IntoLabel for Span {
+impl IntoLabels for Span {
     type FileId<'a> = &'a str;
 
-    fn into_label(&self, style: LabelStyle) -> Label<Self::FileId<'_>> {
-        Label::new(style, self.file_id.as_str(), self.range.clone())
+    fn into_labels(&self, style: LabelStyle) -> Vec<Label<Self::FileId<'_>>> {
+        vec![Label::new(style, self.file_id.as_str(), self.range.clone())]
     }
 }
 

--- a/examples/ref_fileid.rs
+++ b/examples/ref_fileid.rs
@@ -61,6 +61,7 @@ impl IntoLabel for Span {
 #[derive(IntoDiagnostic)]
 // codespan-derive provides a lifetime argument 'a for reference-type file IDs
 #[file_id(&'a str)]
+#[severity(Error)]
 enum Error {
     #[message = "This is an error: {message}"]
     Example {

--- a/examples/severity.rs
+++ b/examples/severity.rs
@@ -39,6 +39,22 @@ enum Error {
     },
 }
 
+#[derive(IntoDiagnostic)]
+#[file_id(usize)]
+#[severity(Warning)]
+enum Warning {
+    #[message = "This is a warning: {message}"]
+    Example {
+        message: &'static str,
+
+        #[primary = "This is a primary span"]
+        primary_span: Span,
+
+        #[secondary = "This is a secondary span"]
+        secondary_span: Span,
+    },
+}
+
 fn main() {
     let mut files: SimpleFiles<&'static str, &'static str> = SimpleFiles::new();
     let file_id = files.add("example.txt", "Test Case");
@@ -55,9 +71,23 @@ fn main() {
         },
     };
 
+    let warn = Warning::Example {
+        message: "This is a stored message",
+        primary_span: Span {
+            file_id,
+            range: 5..9,
+        },
+        secondary_span: Span {
+            file_id,
+            range: 0..4,
+        },
+    };
+
     // Basic codespan-diagnostic printing to terminal
     let writer = StandardStream::stderr(ColorChoice::Always);
     let config = codespan_reporting::term::Config::default();
     term::emit(&mut writer.lock(), &config, &files, &err.into_diagnostic())
+        .expect("Failed to show diagnostic");
+    term::emit(&mut writer.lock(), &config, &files, &warn.into_diagnostic())
         .expect("Failed to show diagnostic");
 }

--- a/proc/src/lib.rs
+++ b/proc/src/lib.rs
@@ -7,7 +7,7 @@ use syn::{
 };
 use synstructure::{decl_derive, Structure};
 
-decl_derive!([IntoDiagnostic, attributes(file_id, message, render, note, primary, secondary)] => diagnostic_derive);
+decl_derive!([IntoDiagnostic, attributes(file_id, severity, message, render, note, primary, secondary)] => diagnostic_derive);
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum FieldName {
@@ -17,6 +17,7 @@ enum FieldName {
 
 fn diagnostic_derive(s: Structure) -> Result<TokenStream> {
     let file_id_attr = syn::parse_str("file_id")?;
+    let severity_attr = syn::parse_str("severity")?;
     let message_attr = syn::parse_str("message")?;
     let render_attr = syn::parse_str("render")?;
     let note_attr = syn::parse_str("note")?;
@@ -28,6 +29,7 @@ fn diagnostic_derive(s: Structure) -> Result<TokenStream> {
     let struct_span = s.ast().span();
 
     let mut file_id = None;
+    let mut severity = None;
 
     for attr in &s.ast().attrs {
         if attr.path == file_id_attr {
@@ -38,6 +40,14 @@ fn diagnostic_derive(s: Structure) -> Result<TokenStream> {
             }
 
             file_id = Some((attr.parse_args::<Type>()?, attr.span()));
+        } else if attr.path == severity_attr {
+            if let Some((_, other_span)) = &severity {
+                let mut err = Error::new(*other_span, "Duplicated #[severity(...)] attribute");
+                err.combine(Error::new(attr.span(), "Second occurrence is here"));
+                return Err(err);
+            }
+
+            severity = Some((attr.parse_args::<Ident>()?, attr.span()));
         } else if attr.path == message_attr
             || attr.path == render_attr
             || attr.path == note_attr
@@ -53,6 +63,9 @@ fn diagnostic_derive(s: Structure) -> Result<TokenStream> {
 
     let file_id = file_id
         .ok_or_else(|| Error::new(struct_span, "Expected `#[file_id(Type)]` attribute"))?
+        .0;
+    let severity = severity
+        .ok_or_else(|| Error::new(struct_span, "Expected `#[severity(Ident)]` attribute"))?
         .0;
 
     let mut branches = vec![];
@@ -144,6 +157,7 @@ fn diagnostic_derive(s: Structure) -> Result<TokenStream> {
             } else if attr.path == primary_attr
                 || attr.path == secondary_attr
                 || attr.path == file_id_attr
+                || attr.path == severity_attr
             {
                 return Err(Error::new(
                     attr.span(),
@@ -186,6 +200,7 @@ fn diagnostic_derive(s: Structure) -> Result<TokenStream> {
                     || attr.path == render_attr
                     || attr.path == note_attr
                     || attr.path == file_id_attr
+                    || attr.path == severity_attr
                 {
                     return Err(Error::new(
                         attr.span(),
@@ -200,7 +215,7 @@ fn diagnostic_derive(s: Structure) -> Result<TokenStream> {
         if let Some((why, _)) = why {
             branches.push(quote! {
                 #pat => {
-                    ::codespan_derive::Diagnostic::error()
+                    ::codespan_derive::Diagnostic::new(::codespan_derive::Severity::#severity)
                         .with_message( #why )
                         .with_labels(vec![ #(#labels),* ])
                         .with_notes(vec![ #(#notes),* ])

--- a/proc/src/lib.rs
+++ b/proc/src/lib.rs
@@ -200,7 +200,7 @@ fn diagnostic_derive(s: Structure) -> Result<TokenStream> {
         if let Some((why, _)) = why {
             branches.push(quote! {
                 #pat => {
-                    ::codespan_derive::Diagnostic::< #file_id >::error()
+                    ::codespan_derive::Diagnostic::error()
                         .with_message( #why )
                         .with_labels(vec![ #(#labels),* ])
                         .with_notes(vec![ #(#notes),* ])
@@ -224,10 +224,10 @@ fn diagnostic_derive(s: Structure) -> Result<TokenStream> {
 
     Ok(s.gen_impl(quote! {
         gen impl ::codespan_derive::IntoDiagnostic for @Self {
-            type FileId = #file_id ;
+            type FileId<'a> = #file_id ;
 
             #[allow(dead_code)]
-            fn into_diagnostic(&self) -> ::codespan_derive::Diagnostic::< #file_id > {
+            fn into_diagnostic(&self) -> ::codespan_derive::Diagnostic::<Self::FileId<'_>> {
                 match self {
                     #(#branches),*
                     _ => { panic!("Uninhabited type cannot be turned into a Diagnostic") }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,17 @@ pub use codespan_derive_proc::IntoDiagnostic;
 pub use codespan_reporting::diagnostic::{Diagnostic, Label, LabelStyle};
 
 pub trait IntoDiagnostic {
-    type FileId;
+    type FileId<'a>: 'a
+    where
+        Self: 'a;
 
-    fn into_diagnostic(&self) -> Diagnostic<Self::FileId>;
+    fn into_diagnostic(&self) -> Diagnostic<Self::FileId<'_>>;
 }
 
 pub trait IntoLabel {
-    type FileId;
+    type FileId<'a>: 'a
+    where
+        Self: 'a;
 
-    fn into_label(&self, style: LabelStyle) -> Label<Self::FileId>;
+    fn into_label(&self, style: LabelStyle) -> Label<Self::FileId<'_>>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 pub use codespan_derive_proc::IntoDiagnostic;
-pub use codespan_reporting::diagnostic::{Diagnostic, Label, LabelStyle};
+pub use codespan_reporting::diagnostic::{Diagnostic, Label, LabelStyle, Severity};
 
 pub trait IntoDiagnostic {
     type FileId<'a>: 'a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,32 @@ pub trait IntoDiagnostic {
     fn into_diagnostic(&self) -> Diagnostic<Self::FileId<'_>>;
 }
 
-pub trait IntoLabel {
+pub trait IntoLabels {
     type FileId<'a>: 'a
     where
         Self: 'a;
 
-    fn into_label(&self, style: LabelStyle) -> Label<Self::FileId<'_>>;
+    fn into_labels(&self, style: LabelStyle) -> Vec<Label<Self::FileId<'_>>>;
+}
+
+/// Impl for optional labels
+impl<T: IntoLabels> IntoLabels for Option<T> {
+    type FileId<'a> = T::FileId<'a> where T: 'a;
+
+    fn into_labels(&self, style: LabelStyle) -> Vec<Label<Self::FileId<'_>>> {
+        self.iter()
+            .flat_map(|x| x.into_labels(style))
+            .collect()
+    }
+}
+
+/// Impl for multiple labels
+impl<T: IntoLabels> IntoLabels for Vec<T> {
+    type FileId<'a> = T::FileId<'a> where T: 'a;
+
+    fn into_labels(&self, style: LabelStyle) -> Vec<Label<Self::FileId<'_>>> {
+        self.iter()
+            .flat_map(|x| x.into_labels(style))
+            .collect()
+    }
 }


### PR DESCRIPTION
Thanks to @bjchambers for the implementation idea. `IntoLabels` asks for a vector of labels, and blanket impls are provided for `Option<T>` and `Vec<T>`. Fixes #4.

Includes commits from #7, I recommend merging that first